### PR TITLE
feat: add docker-compose and offline tokenizer support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,5 +59,11 @@ COPY ./*.py .
 COPY ./logging.conf .
 COPY ./inputs.json .
 
+# Pre-download the default tokenizer so the image can run offline.
+# Override TOKENIZER_MODEL at build time to cache a different model.
+ARG TOKENIZER_MODEL=NousResearch/Meta-Llama-3.1-8B-Instruct
+ENV HF_HOME=/app/.cache/huggingface
+RUN python -c "from transformers import AutoTokenizer; AutoTokenizer.from_pretrained('${TOKENIZER_MODEL}')"
+
 # Default command to run the API server
 ENTRYPOINT ["python", "api.py"]

--- a/README.md
+++ b/README.md
@@ -16,5 +16,46 @@ cd webui && yarn && yarn run build
 cd .. && python api.py
 ```
 
+## Running with Docker Compose
+
+The easiest way to get started is with Docker Compose. It builds the frontend and backend into a single image and pre-downloads the default tokenizer so the container can run offline.
+
+```bash
+docker compose up --build
+```
+
+The UI will be available at `http://localhost:8089`.
+
+### Customizing the tokenizer
+
+To cache a different tokenizer model during the build:
+
+```bash
+docker compose build --build-arg TOKENIZER_MODEL=meta-llama/Llama-2-7b-hf
+docker compose up
+```
+
+### Running fully offline
+
+After building the image with the desired tokenizer, enable offline mode so no network calls are made at runtime:
+
+```bash
+# In docker-compose.yml, uncomment the HF_HUB_OFFLINE line, then:
+docker compose up
+```
+
+## Running with Docker (without Compose)
+
+```bash
+docker build -t llm-locust .
+docker run -p 8089:8089 llm-locust
+```
+
+To pass CLI arguments:
+
+```bash
+docker run -p 8089:8089 llm-locust --host http://your-llm-server:8000 --model your-model-name
+```
+
 # How it works
 ![design diagram](image.png)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  llm-locust:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Cache the default tokenizer during build for offline usage.
+        # Override this to cache a different tokenizer model.
+        TOKENIZER_MODEL: NousResearch/Meta-Llama-3.1-8B-Instruct
+    ports:
+      - "8089:8089"
+    environment:
+      # HuggingFace cache directory inside the container
+      - HF_HOME=/app/.cache/huggingface
+      # Uncomment to run fully offline (requires tokenizer cached at build time)
+      # - HF_HUB_OFFLINE=1
+    volumes:
+      # Persist HuggingFace cache across container restarts
+      - hf-cache:/app/.cache/huggingface
+
+volumes:
+  hf-cache:


### PR DESCRIPTION
## Summary

Closes #9

This PR adds Docker Compose support and enables fully offline usage
by pre-downloading the HuggingFace tokenizer at build time.

### Changes
- **`docker-compose.yml`** (new) — Single-command startup via
  `docker compose up --build`. Includes a named volume to persist
  the HuggingFace cache across restarts and an optional
  `HF_HUB_OFFLINE` flag for air-gapped environments.
- **`Dockerfile`** — Added a build stage that pre-downloads the
  default tokenizer (`NousResearch/Meta-Llama-3.1-8B-Instruct`)
  into the image. The model can be overridden with
  `--build-arg TOKENIZER_MODEL=<model>`.
- **`README.md`** — Added documentation for running with Docker
  Compose, customizing the tokenizer, running offline, and using
  plain Docker.

### How to test
1. `docker compose up --build`
2. Open `http://localhost:8089`
3. For offline mode: uncomment `HF_HUB_OFFLINE=1` in
   docker-compose.yml and restart

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to container build/runtime configuration and docs, with the main impact being increased image build time/size due to tokenizer pre-download.
> 
> **Overview**
> Adds `docker-compose.yml` for one-command startup, including a persisted HuggingFace cache volume and an optional `HF_HUB_OFFLINE` toggle for fully offline runtime.
> 
> Updates the `Dockerfile` to pre-download a tokenizer at build time (configurable via `TOKENIZER_MODEL`) and sets `HF_HOME` to an in-container cache directory. Expands `README.md` with Compose/Docker run instructions, tokenizer override steps, and offline guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bc144c21d35862a3422da9743970d85244f8a69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->